### PR TITLE
add Dockerfile to support OpenROAD unified build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.gitignore
+Dockerfile
+
+# from .gitignore
+*.log
+*.swo
+*.swd
+*.swp
+*/**/*.o
+
+Makefile
+CMakeCache.txt
+*.cmake
+CMakeFiles
+install_manifest.txt
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM centos:centos6 AS builder
+
+# install gcc 6
+RUN yum -y install centos-release-scl && \
+    yum -y install devtoolset-6 devtoolset-6-libatomic-devel
+ENV CC=/opt/rh/devtoolset-6/root/usr/bin/gcc \
+    CPP=/opt/rh/devtoolset-6/root/usr/bin/cpp \
+    CXX=/opt/rh/devtoolset-6/root/usr/bin/g++ \
+    PATH=/opt/rh/devtoolset-6/root/usr/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib:/opt/rh/devtoolset-6/root/usr/lib64/dyninst:/opt/rh/devtoolset-6/root/usr/lib/dyninst:/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib:$LD_LIBRARY_PATH
+
+# Common development tools and libraries (kitchen sink approach)
+RUN yum groupinstall -y "Development Tools" "Development Libraries"
+
+RUN yum -y install wget zlib-devel
+
+RUN wget https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.sh && \
+    chmod +x cmake-3.9.0-Linux-x86_64.sh  && \
+    ./cmake-3.9.0-Linux-x86_64.sh --skip-license --prefix=/usr/local
+
+
+COPY . /OpenDP
+RUN mkdir /OpenDP/build
+WORKDIR /OpenDP/build
+RUN cmake .. && \
+ make && \
+ make install
+
+# runtime environment
+FROM centos:centos6 AS runner
+RUN yum update -y && yum install -y tcl-devel libgomp
+COPY --from=builder /OpenDP/build/opendp /build/opendp
+RUN useradd -ms /bin/bash openroad
+USER openroad
+WORKDIR /home/openroad


### PR DESCRIPTION
This pull request adds a Dockerfile to the repository to integrate in the unified build environment. The image is based on centos6, which is the agreed build environment for OpenROAD.

To build:
`docker build -t <image_name> .`

Binaries are in `/build` directory, which can also be run from within the container.