### PR TITLE
avoid float calculation error in num of rows

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -194,7 +194,7 @@ void circuit::read_files(int argc, char* argv[]) {
   int site_offset = rows[0].origX;
 
   // construct pixel grid
-  int row_num = ty / rowHeight;
+  int row_num = round(ty / rowHeight);
   int col = rx / wsite;
   grid = new pixel*[row_num];
   for(int i = 0; i < row_num; i++) {


### PR DESCRIPTION
Hello. During parsing the def, rowHeight can be set to a floating number like this `4070.0000000000005`. And so during constructing pixel gird as seen here https://github.com/The-OpenROAD-Project/OpenDP/blob/f51d84c3babdbe32a7f6469de0eacfefcb9b8c39/src/parser.cpp#L199 row number will be less than what it is and results in seg fault.

This is a gdb output that can help clarify the issue.
```
(gdb) p sites[2].height  * static_cast< double >(DEFdist2Microns)
$4 = 4070.0000000000005
(gdb) p row_num
$6 = 29
(gdb) p ty
$7 = 122100
(gdb) p rowHeight
$8 = 4070.0000000000005
(gdb) p ty / rowHeight
$9 = 29.999999999999996
(gdb) 
```
Since `ty / rowHeight` is casted to `int` it reflects a wrong number. 
This PR suggests a fix. If you wish, you can close it and implement a fix of your chosing.

Thanks